### PR TITLE
Add reprints of implemented cards to AYR/DMS/ANK/TSL/VLN

### DIFF
--- a/Mage.Sets/src/mage/cards/t/ThundersongTrumpeter.java
+++ b/Mage.Sets/src/mage/cards/t/ThundersongTrumpeter.java
@@ -25,6 +25,7 @@ public final class ThundersongTrumpeter extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{R}{W}");
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.SOLDIER);
+        this.subtype.add(SubType.BARD);
         this.power = new MageInt(2);
         this.toughness = new MageInt(1);
 

--- a/Mage.Sets/src/mage/sets/Aenyr.java
+++ b/Mage.Sets/src/mage/sets/Aenyr.java
@@ -27,6 +27,16 @@ public final class Aenyr extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
 
-        //TODO cards
+        cards.add(new SetCardInfo("Blood Artist", 49, Rarity.UNCOMMON, mage.cards.b.BloodArtist.class));
+        cards.add(new SetCardInfo("Forest", 254, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Island", 251, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Mountain", 253, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Painter's Servant", 230, Rarity.RARE, mage.cards.p.PaintersServant.class));
+        cards.add(new SetCardInfo("Plains", 250, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Satyr Wayfinder", 106, Rarity.COMMON, mage.cards.s.SatyrWayfinder.class));
+        cards.add(new SetCardInfo("Springleaf Drum", 233, Rarity.COMMON, mage.cards.s.SpringleafDrum.class));
+        cards.add(new SetCardInfo("Swamp", 252, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Thundersong Trumpeter", 185, Rarity.COMMON, mage.cards.t.ThundersongTrumpeter.class));
+        cards.add(new SetCardInfo("Ultimate Price", 66, Rarity.UNCOMMON, mage.cards.u.UltimatePrice.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/Ankheret.java
+++ b/Mage.Sets/src/mage/sets/Ankheret.java
@@ -23,7 +23,43 @@ public final class Ankheret extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
+        cards.add(new SetCardInfo("Annex", 39, Rarity.UNCOMMON, mage.cards.a.Annex.class));
+        cards.add(new SetCardInfo("Bonds of Faith", 4, Rarity.COMMON, mage.cards.b.BondsOfFaith.class));
+        cards.add(new SetCardInfo("Cobra Trap", 150, Rarity.UNCOMMON, mage.cards.c.CobraTrap.class));
+        cards.add(new SetCardInfo("Cone of Flame", 120, Rarity.UNCOMMON, mage.cards.c.ConeOfFlame.class));
+        cards.add(new SetCardInfo("Crumbling Vestige", 233, Rarity.COMMON, mage.cards.c.CrumblingVestige.class));
+        cards.add(new SetCardInfo("Demolish", 122, Rarity.COMMON, mage.cards.d.Demolish.class));
+        cards.add(new SetCardInfo("Desolate Lighthouse", 235, Rarity.RARE, mage.cards.d.DesolateLighthouse.class));
+        cards.add(new SetCardInfo("Disentomb", 82, Rarity.COMMON, mage.cards.d.Disentomb.class));
+        cards.add(new SetCardInfo("Divination", 45, Rarity.COMMON, mage.cards.d.Divination.class));
+        cards.add(new SetCardInfo("Expedition Map", 215, Rarity.COMMON, mage.cards.e.ExpeditionMap.class));
+        cards.add(new SetCardInfo("Fade into Antiquity", 158, Rarity.COMMON, mage.cards.f.FadeIntoAntiquity.class));
+        cards.add(new SetCardInfo("Forest", 262, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Forest", 263, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Forest", 264, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Giant Growth", 159, Rarity.COMMON, mage.cards.g.GiantGrowth.class));
+        cards.add(new SetCardInfo("Harness the Storm", 130, Rarity.RARE, mage.cards.h.HarnessTheStorm.class));
+        cards.add(new SetCardInfo("Island", 253, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Island", 254, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Island", 255, Rarity.LAND, mage.cards.basiclands.Island.class));
         cards.add(new SetCardInfo("Ma'at, God of Harmony", 165, Rarity.MYTHIC, mage.cards.m.MaatGodOfHarmony.class));
+        cards.add(new SetCardInfo("Mana Confluence", 239, Rarity.RARE, mage.cards.m.ManaConfluence.class));
+        cards.add(new SetCardInfo("Mountain", 259, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Mountain", 260, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Mountain", 261, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Pilgrim's Eye", 220, Rarity.UNCOMMON, mage.cards.p.PilgrimsEye.class));
+        cards.add(new SetCardInfo("Plains", 250, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Plains", 251, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Plains", 252, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Sanctuary Cat", 28, Rarity.COMMON, mage.cards.s.SanctuaryCat.class));
+        cards.add(new SetCardInfo("Scapeshift", 175, Rarity.RARE, mage.cards.s.Scapeshift.class));
+        cards.add(new SetCardInfo("Sphinx's Revelation", 204, Rarity.MYTHIC, mage.cards.s.SphinxsRevelation.class));
+        cards.add(new SetCardInfo("Swamp", 256, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Swamp", 257, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Swamp", 258, Rarity.LAND, mage.cards.basiclands.Swamp.class));
         cards.add(new SetCardInfo("The Scorpion King", 202, Rarity.RARE, mage.cards.t.TheScorpionKing.class));
+        cards.add(new SetCardInfo("Unknown Shores", 248, Rarity.COMMON, mage.cards.u.UnknownShores.class));
+        cards.add(new SetCardInfo("Vengeful Pharaoh", 110, Rarity.RARE, mage.cards.v.VengefulPharaoh.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/Dreamscape.java
+++ b/Mage.Sets/src/mage/sets/Dreamscape.java
@@ -27,6 +27,18 @@ public final class Dreamscape extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
 
-        //TODO cards
+        cards.add(new SetCardInfo("Abundant Growth", 162, Rarity.COMMON, mage.cards.a.AbundantGrowth.class));
+        cards.add(new SetCardInfo("Dissipate", 47, Rarity.UNCOMMON, mage.cards.d.Dissipate.class));
+        cards.add(new SetCardInfo("Forest", 255, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Fortress Crab", 54, Rarity.COMMON, mage.cards.f.FortressCrab.class));
+        cards.add(new SetCardInfo("Island", 252, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Mountain", 254, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Pestermite", 68, Rarity.COMMON, mage.cards.p.Pestermite.class));
+        cards.add(new SetCardInfo("Plains", 251, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Recumbent Bliss", 27, Rarity.UNCOMMON, mage.cards.r.RecumbentBliss.class));
+        cards.add(new SetCardInfo("Shambling Ghoul", 114, Rarity.COMMON, mage.cards.s.ShamblingGhoul.class));
+        cards.add(new SetCardInfo("Sleep", 74, Rarity.UNCOMMON, mage.cards.s.Sleep.class));
+        cards.add(new SetCardInfo("Swamp", 253, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Think Twice", 78, Rarity.COMMON, mage.cards.t.ThinkTwice.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/MagicVillains.java
+++ b/Mage.Sets/src/mage/sets/MagicVillains.java
@@ -27,6 +27,35 @@ public final class MagicVillains extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
 
-        //TODO cards
+        cards.add(new SetCardInfo("Baloth Cage Trap", 157, Rarity.UNCOMMON, mage.cards.b.BalothCageTrap.class));
+        cards.add(new SetCardInfo("Cage of Hands", 4, Rarity.COMMON, mage.cards.c.CageOfHands.class));
+        cards.add(new SetCardInfo("Defiant Strike", 6, Rarity.COMMON, mage.cards.d.DefiantStrike.class));
+        cards.add(new SetCardInfo("Disembowel", 94, Rarity.COMMON, mage.cards.d.Disembowel.class));
+        cards.add(new SetCardInfo("Evolving Wilds", 235, Rarity.COMMON, mage.cards.e.EvolvingWilds.class));
+        cards.add(new SetCardInfo("Forest", 266, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Forest", 267, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Forest", 268, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Forest", 269, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Island", 254, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Island", 255, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Island", 256, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Island", 257, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Mountain", 262, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Mountain", 263, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Mountain", 264, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Mountain", 265, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Nemesis Mask", 226, Rarity.UNCOMMON, mage.cards.n.NemesisMask.class));
+        cards.add(new SetCardInfo("Pilgrim's Eye", 228, Rarity.COMMON, mage.cards.p.PilgrimsEye.class));
+        cards.add(new SetCardInfo("Plains", 250, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Plains", 251, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Plains", 252, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Plains", 253, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Satyr Wayfinder", 180, Rarity.COMMON, mage.cards.s.SatyrWayfinder.class));
+        cards.add(new SetCardInfo("Strategic Planning", 70, Rarity.COMMON, mage.cards.s.StrategicPlanning.class));
+        cards.add(new SetCardInfo("Swamp", 258, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Swamp", 259, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Swamp", 260, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Swamp", 261, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Tezzeret's Ambition", 72, Rarity.COMMON, mage.cards.t.TezzeretsAmbition.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/Tesla.java
+++ b/Mage.Sets/src/mage/sets/Tesla.java
@@ -27,6 +27,22 @@ public final class Tesla extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
 
-        //TODO cards
+        cards.add(new SetCardInfo("Cinder Barrens", 238, Rarity.UNCOMMON, mage.cards.c.CinderBarrens.class));
+        cards.add(new SetCardInfo("Explosive Apparatus", 216, Rarity.COMMON, mage.cards.e.ExplosiveApparatus.class));
+        cards.add(new SetCardInfo("Favorable Winds", 44, Rarity.UNCOMMON, mage.cards.f.FavorableWinds.class));
+        cards.add(new SetCardInfo("Forest", 254, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Ghirapur Gearcrafter", 123, Rarity.COMMON, mage.cards.g.GhirapurGearcrafter.class));
+        cards.add(new SetCardInfo("Island", 251, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Make Obsolete", 88, Rarity.UNCOMMON, mage.cards.m.MakeObsolete.class));
+        cards.add(new SetCardInfo("Meandering River", 243, Rarity.UNCOMMON, mage.cards.m.MeanderingRiver.class));
+        cards.add(new SetCardInfo("Mountain", 253, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Negate", 59, Rarity.COMMON, mage.cards.n.Negate.class));
+        cards.add(new SetCardInfo("Plains", 250, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Scouring Sands", 136, Rarity.COMMON, mage.cards.s.ScouringSands.class));
+        cards.add(new SetCardInfo("Submerged Boneyard", 245, Rarity.UNCOMMON, mage.cards.s.SubmergedBoneyard.class));
+        cards.add(new SetCardInfo("Swamp", 252, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Timber Gorge", 246, Rarity.UNCOMMON, mage.cards.t.TimberGorge.class));
+        cards.add(new SetCardInfo("Tranquil Expanse", 247, Rarity.UNCOMMON, mage.cards.t.TranquilExpanse.class));
+        cards.add(new SetCardInfo("Unwilling Recruit", 141, Rarity.UNCOMMON, mage.cards.u.UnwillingRecruit.class));
     }
 }

--- a/Mage/src/main/java/mage/constants/SubType.java
+++ b/Mage/src/main/java/mage/constants/SubType.java
@@ -68,6 +68,7 @@ public enum SubType {
     BADGER("Badger", SubTypeSet.CreatureType),
     BARABEL("Barabel", SubTypeSet.CreatureType, true), // Star Wars
     BARBARIAN("Barbarian", SubTypeSet.CreatureType),
+    BARD("Bard", SubTypeSet.CreatureType), // Aenyr
     BASILISK("Basilisk", SubTypeSet.CreatureType),
     BAT("Bat", SubTypeSet.CreatureType),
     BEAR("Bear", SubTypeSet.CreatureType),


### PR DESCRIPTION
Includes Thundersong Trumpeter, which is now a Bard.